### PR TITLE
implicit macro

### DIFF
--- a/.changeset/green-flies-joke.md
+++ b/.changeset/green-flies-joke.md
@@ -1,0 +1,5 @@
+---
+"scalawind": minor
+---
+
+implicit macro

--- a/packages/scalawind/src/templates/scalawind.hbs
+++ b/packages/scalawind/src/templates/scalawind.hbs
@@ -8,15 +8,15 @@ object clx {
   {{/each}}
 }
 
-case class SwStyle(style: String = "") {
-  def addClasses(classNames: String): SwStyle = {
+case class TwStyle(style: String = "") {
+  def addClasses(classNames: String): TwStyle = {
     val newStyle = s"$style ${classNames}".trim
-    SwStyle(newStyle)
+    TwStyle(newStyle)
   }
-  def addClass(className: String): SwStyle = addClasses(className)
+  def addClass(className: String): TwStyle = addClasses(className)
 
   {{#each modifiers}}
-  def {{this}}(styles: SwStyle): SwStyle = {
+  def {{this}}(styles: TwStyle): TwStyle = {
     val classes = styles.style.split("\\s+").map(clx => s"{{this}}:$clx").mkString(" ")
     addClasses(classes)
   }
@@ -25,30 +25,28 @@ case class SwStyle(style: String = "") {
   override def toString: String = style
 }
 
-given Conversion[SwStyle, String] with
-  def apply(swStyle: SwStyle): String = swStyle.style
-
-extension (swStyle: SwStyle)
-  {{#each standard}}
-  def {{this.prop}}: SwStyle = swStyle.addClass(clx.{{this.prop}})
-  {{/each}}
-
 object tw {
   def apply(): SwStyle = SwStyle()
 
   {{#each standard}}
-  def {{this.prop}}: SwStyle = SwStyle().addClass(clx.{{this.prop}})
+  def {{this.prop}}: TwStyle = TwStyle().addClass(clx.{{this.prop}})
   {{/each}}
 
   {{#each modifiers}}
-  def {{this}}(styles: SwStyle): SwStyle = SwStyle().{{this}}(styles)
+  def {{this}}(styles: TwStyle): TwStyle = TwStyle().{{this}}(styles)
   {{/each}}
 }
 
-inline def sw(inline styles: SwStyle): String =
-  ${ swImpl('styles) }
+extension (twStyle: TwStyle)
+  {{#each standard}}
+  def {{this.prop}}: TwStyle = twStyle.addClass(clx.{{this.prop}})
+  {{/each}}
 
-private def swImpl(stylesExpr: Expr[SwStyle])(using Quotes): Expr[String] = {
+inline implicit def sw(inline twStyle: TwStyle): String =
+  ${ swImpl('twStyle) }
+
+
+def swImpl(twStyleExpr: Expr[TwStyle])(using Quotes): Expr[String] = {
   import quotes.reflect.*
 
   def extractClassNames(term: Term): List[String] = term match {
@@ -57,21 +55,26 @@ private def swImpl(stylesExpr: Expr[SwStyle])(using Quotes): Expr[String] = {
       val classes = extractClassNames(styles).map(clx => s"{{this}}:$clx")
       extractClassNames(inner) ++ classes
     {{/each}}
+    case Apply(Select(inner, "md"), List(mdStyle)) =>
+      val mdClasses = extractClassNames(mdStyle).map(cls => s"md:$cls")
+      extractClassNames(inner) ++ mdClasses
     case Apply(Ident(name), List(inner)) =>
       extractClassNames(inner) :+ name.replace("_", "-")
     case Inlined(_, _, inner) =>
       extractClassNames(inner)
     case Select(inner, name) =>
       extractClassNames(inner) :+ name.replace("_", "-")
+    case Ident("twStyle") =>
+      Nil
     case Ident("tw") =>
       Nil
     case _ =>
       report.errorAndAbort(s"Unexpected term: $term")
   }
 
-  val term = stylesExpr.asTerm
+  val term = twStyleExpr.asTerm
   val classNames = extractClassNames(term)
   val combinedClasses = classNames.mkString(" ")
-  report.info(s"Compiled: $combinedClasses")
+  report.info(s"Compiled classes: $combinedClasses")
   Expr(combinedClasses)
 }


### PR DESCRIPTION
We can get rid of the `sw()` call by making it implicit.

![image](https://github.com/nguyenyou/scalawind/assets/38455472/551727d6-d662-484c-bcdf-ce25e30fecf4)
